### PR TITLE
fix: display the real Go commands

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -16,11 +16,11 @@ func mainModule() (dir string, packages map[string]struct{}, _ error) {
 	// especially on macOS, which has the default soft limit set to 256 (ulimit -nS).
 	// Since go1.19 the limit is automatically increased to the maximum allowed value;
 	// see https://github.com/golang/go/issues/46279 for details.
-	cmd := [...]string{"go", "list", "-f={{if and (not .Standard) .Module.Main}}{{.ImportPath}}{{end}}", "all"}
+	args := []string{"go", "list", "-f={{if and (not .Standard) .Module.Main}}{{.ImportPath}}{{end}}", "all"}
 
-	out, err := exec.Command(cmd[0], cmd[1:]...).Output()
+	out, err := exec.Command(args[0], args[1:]...).Output()
 	if err != nil {
-		return "", nil, fmt.Errorf("running `go list all`: %w", err)
+		return "", nil, fmt.Errorf("running `%s`: %w", strings.Join(args, " "), err)
 	}
 
 	list := strings.Split(strings.TrimSpace(string(out)), "\n")
@@ -31,9 +31,10 @@ func mainModule() (dir string, packages map[string]struct{}, _ error) {
 		packages[pkg+"_test"] = struct{}{} // `*_test` packages belong to the main module, see issue #24.
 	}
 
-	out, err = exec.Command("go", "list", "-m", "-f={{.Dir}}").Output()
+	args = []string{"go", "list", "-m", "-f={{.Dir}}"}
+	out, err = exec.Command(args[0], args[1:]...).Output()
 	if err != nil {
-		return "", nil, fmt.Errorf("running `go list -m`: %w", err)
+		return "", nil, fmt.Errorf("running `%s`: %w", strings.Join(args, " "), err)
 	}
 
 	dir = strings.TrimSpace(string(out))


### PR DESCRIPTION
Display the real Go commands when there is an error inside the `mainModule` function.

