### PR TITLE
Fix running in Go workspace

### DIFF
--- a/testdata/src/go.work
+++ b/testdata/src/go.work
@@ -1,0 +1,7 @@
+go 1.18
+
+use (
+	./builtins
+	./custom
+	./tests
+)

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package musttag
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,32 +10,40 @@ import (
 	"strings"
 )
 
+var (
+	getwd = os.Getwd
+
+	commandOutput = func(name string, args ...string) (string, error) {
+		output, err := exec.Command(name, args...).Output()
+		return string(output), err
+	}
+)
+
 func getMainModule() (string, error) {
 	args := []string{"go", "list", "-m", "-json"}
 
-	data, err := exec.Command(args[0], args[1:]...).Output()
+	output, err := commandOutput(args[0], args[1:]...)
 	if err != nil {
 		return "", fmt.Errorf("running `%s`: %w", strings.Join(args, " "), err)
 	}
 
-	var module struct {
-		Path      string `json:"Path"`
-		Main      bool   `json:"Main"`
-		Dir       string `json:"Dir"`
-		GoMod     string `json:"GoMod"`
-		GoVersion string `json:"GoVersion"`
-	}
-
-	cwd, _ := os.Getwd()
-	decoder := json.NewDecoder(bytes.NewBuffer(data))
+	cwd, _ := getwd()
+	decoder := json.NewDecoder(strings.NewReader(output))
 
 	for {
+		// multiple JSON objects will be returned when using Go workspaces; see #63 for details.
+		var module struct {
+			Path      string `json:"Path"`
+			Main      bool   `json:"Main"`
+			Dir       string `json:"Dir"`
+			GoMod     string `json:"GoMod"`
+			GoVersion string `json:"GoVersion"`
+		}
 		if err := decoder.Decode(&module); err != nil {
 			if errors.Is(err, io.EOF) {
-				return "", fmt.Errorf("no main module in: %s", string(data))
+				return "", fmt.Errorf("main module not found\n%s", output)
 			}
-
-			return "", fmt.Errorf("decoding json: %w: %s", err, string(data))
+			return "", fmt.Errorf("decoding json: %w\n%s", err, output)
 		}
 
 		if module.Main && strings.HasPrefix(cwd, module.Dir) {

--- a/utils.go
+++ b/utils.go
@@ -27,7 +27,11 @@ func getMainModule() (string, error) {
 		return "", fmt.Errorf("running `%s`: %w", strings.Join(args, " "), err)
 	}
 
-	cwd, _ := getwd()
+	cwd, err := getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting wd: %w", err)
+	}
+
 	decoder := json.NewDecoder(strings.NewReader(output))
 
 	for {

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,12 +12,21 @@ func Test_getMainModule(t *testing.T) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
+
+			gwd := getwd
+			co := commandOutput
+			defer func() {
+				getwd = gwd
+				commandOutput = co
+			}()
+
 			getwd = func() (string, error) {
 				return "/path/to/module1/pkg", nil
 			}
 			commandOutput = func(name string, args ...string) (string, error) {
 				return output, nil
 			}
+
 			got, err := getMainModule()
 			assert.NoErr[F](t, err)
 			assert.Equal[E](t, got, want)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,45 @@
+package musttag
+
+import (
+	"testing"
+
+	"go-simpler.org/assert"
+	. "go-simpler.org/assert/dotimport"
+)
+
+func Test_getMainModule(t *testing.T) {
+	test := func(name, want, output string) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			getwd = func() (string, error) {
+				return "/path/to/module1/pkg", nil
+			}
+			commandOutput = func(name string, args ...string) (string, error) {
+				return output, nil
+			}
+			got, err := getMainModule()
+			assert.NoErr[F](t, err)
+			assert.Equal[E](t, got, want)
+		})
+	}
+
+	test("single module", "module1", `
+{
+	"Path": "module1",
+	"Main": true,
+	"Dir": "/path/to/module1"
+}`)
+
+	test("multiple modules", "module1", `
+{
+	"Path": "module1",
+	"Main": true,
+	"Dir": "/path/to/module1"
+}
+{
+	"Path": "module2",
+	"Main": true,
+	"Dir": "/path/to/module2"
+}`)
+}


### PR DESCRIPTION
When working with Go workspaces, `go list -m -json` will return multiple objects. For example:

```json
{
	"Path": "golang.org/x/example/hello",
	"Main": true,
	"Dir": "/build/example/hello",
	"GoMod": "/build/example/hello/go.mod",
	"GoVersion": "1.19"
}
{
	"Path": "example.com/hello",
	"Main": true,
	"Dir": "/build/hello",
	"GoMod": "/build/hello/go.mod",
	"GoVersion": "1.21"
}
```

Ensure that the JSON decoding can handle this output by stream-decoding the JSON and returning the first suitable module.